### PR TITLE
fix argument corruption

### DIFF
--- a/lib/facebook_ads/session.rb
+++ b/lib/facebook_ads/session.rb
@@ -36,10 +36,9 @@ module FacebookAds
     end
 
     def request(method, path, params = nil)
-      path.gsub!(/^\//,'') #
       case method
         when :get, :post, :delete
-          api_conn.send(method, path, params) do |req|
+          api_conn.send(method, path.gsub(/^\//,''), params) do |req|
             req.headers[:user_agent] = "fbbizsdk-ruby-v#{API_VERSION}".freeze
             req.params[:access_token] = access_token
             req.params[:appsecret_proof] = appsecret_proof if app_secret


### PR DESCRIPTION
When the version was changed to 3.0.0,  #26 had disappeared

https://github.com/facebook/facebook-ruby-business-sdk/commit/1b69dbe335d7e7701c971c98e1ce78e0e97a72d7#diff-4103b0b464bbed61824319d7aaaae92b
ref https://github.com/facebook/facebook-ruby-business-sdk/issues/22
ref https://github.com/facebook/facebook-ruby-business-sdk/pull/26