### PR TITLE
Fixed bad reference for games_achieves

### DIFF
--- a/lib/facebook_ads/ad_objects/user.rb
+++ b/lib/facebook_ads/ad_objects/user.rb
@@ -469,7 +469,7 @@ module FacebookAds
       end
     end
 
-    has_edge :games.achieves do |edge|
+    has_edge :games_achieves do |edge|
       edge.post do |api|
         api.has_param :added, 'string'
         api.has_param :alias, 'string'


### PR DESCRIPTION
In version 0.3.3.3,
`FacebookAds::User` cannot be initialized because of this invalid syntax: 
The auto-generated code `:games.achieves` is invalid syntax. This change is to fix it to `:games_achieves`