### PR TITLE
Add getHeaders in APIError class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Unreleased
+  - Added function `getHeaders` in errors class which provides header information
 
 ## v0.5.0.2
 
@@ -33,4 +34,3 @@ All notable changes to this project will be documented in this file.
 ## v0.3.3.0
 ### Changed
 - Graph API call upgrade to [v3.3](https://developers.facebook.com/docs/graph-api/changelog/version3.3)
-

--- a/lib/facebook_ads/api_response.rb
+++ b/lib/facebook_ads/api_response.rb
@@ -38,6 +38,10 @@ module FacebookAds
       @body
     end
 
+    def headers
+      @headers
+    end
+
     private
     def is_json_response?
       headers[:content_type] =~ /application\/json/ ||

--- a/lib/facebook_ads/errors.rb
+++ b/lib/facebook_ads/errors.rb
@@ -24,7 +24,7 @@ module FacebookAds
 
   class APIError < Error
     ERROR_ATTRS = [
-      :fb_message, :type, :code,
+      :headers, :fb_message, :type, :code,
       :error_subcode, :is_transient, :error_user_title,
       :error_user_msg, :fbtrace_id,
     ]
@@ -32,6 +32,7 @@ module FacebookAds
     attr_accessor *ERROR_ATTRS
 
     def initialize(api_response)
+      send("headers=", api_response.headers)
       error_obj = api_response.result
       @api_response = api_response
 
@@ -46,6 +47,10 @@ module FacebookAds
       else
         super(error_obj)
       end
+    end
+
+    def getHeaders
+      self.headers
     end
   end
 


### PR DESCRIPTION
Summary:
1. Added headers in the Attribute
2. Added function getHeaders

This diff will provides the whole header information of APIException to developer.

Reviewed By: jingping2015

Differential Revision: D18509658

