### PR TITLE
Add error data field to error response

### DIFF
--- a/lib/facebook_ads/errors.rb
+++ b/lib/facebook_ads/errors.rb
@@ -26,7 +26,7 @@ module FacebookAds
     ERROR_ATTRS = [
       :headers, :fb_message, :type, :code,
       :error_subcode, :is_transient, :error_user_title,
-      :error_user_msg, :fbtrace_id,
+      :error_user_msg, :error_data, :fbtrace_id,
     ]
 
     attr_accessor *ERROR_ATTRS


### PR DESCRIPTION
I am working on some code that uses the [`validate_only`, `include_recommendations`, `synchronous_ad_review`] execution options when creating an ad to check whether or not it will be penalized for having too much image text.

However, when making the API call to create an ad with these execution options, the error response I get back does not include the information required to determine if it's being flagged as having too much text. I submitted the same request in the Graph API explorer and got much of the same information back, in addition to the `error_data` information which included what I needed, as well as other helpful information. 

This PR will hopefully provide more error information to users who would like it. Thanks for the consideration!