### PR TITLE
Update ruby version in .travis.yml to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.3
+- 2.4
 before_install:
 - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
 - gem install bundler -v '< 2'


### PR DESCRIPTION
Build start failing after 6fb5febe774d4efaabea3309465ce2c7dd015b22 merged. Most of updated gems require ruby >= 2.4