### PR TITLE
Make summary results accessible to edges

### DIFF
--- a/lib/facebook_ads/edge.rb
+++ b/lib/facebook_ads/edge.rb
@@ -55,6 +55,11 @@ module FacebookAds
       self.has_next_page = true
     end
 
+    def summary
+      fetch_next_page if @summary.nil?
+      @summary ||= {}
+    end
+
     private
     def fetch_next_page
       fetch_options = {limit: DEFAULT_PAGE_SIZE}.merge(serialized_options)
@@ -70,6 +75,7 @@ module FacebookAds
 
         self.next_page_cursor = response.dig('paging', 'cursors', 'after')
         self.has_next_page = !(response['data'].length < fetch_options[:limit])
+        @summary = response['summary'] || {}
       end
     end
 
@@ -95,7 +101,7 @@ module FacebookAds
       node.post_edge(name, graph_params.merge(params)) do |response|
         # TODO params check
         # TODO Add new object to collection?
-        
+
         field_type = self.class.return_types[:post]
 
         obj = field_type.deserialize(response, node.session)


### PR DESCRIPTION
### What's the issue?
When fetching an edge, there is no way to get at any summary data that might be returned.

### Steps/Sample code to reproduce the issue
```
fb_session = FacebookAds::Session.new(access_token: 'token', app_secret: 'secret')
fb_post = FacebookAds::PagePost.get('xxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxx', 'message', fb_session)
fb_comments = fb_post.comments(summary: 'total_count')
```
#### Observed Results:
Turning on logs, I can see that the total_count for the number of comments here is returned, but the SDK just ignores it and it remains inaccessible. Example JSON returned:
```
{
  "data": [
    {
      "created_time": ...,
      "message": ...,
      "id": ...
    },
    ...
  ],
  "paging": {
    "cursors": {
      "before": ...,
      "after": ...
    },
    "next": ...
  },
  "summary": {
    "total_count": 110
  }
}
```

#### Fix:
Store any summary results into the summary property on the Edge object. Now,
```
2.6.5 :006 > fb_comments.summary
 => {"total_count"=>110}
```
