### PR TITLE
Update with_session method params

### DIFF
--- a/lib/facebook_ads.rb
+++ b/lib/facebook_ads.rb
@@ -29,8 +29,8 @@ module FacebookAds
 
   def with_session(access_token, secret = nil, api_version = DEFAULT_API_VERSION)
     original_session = Session.current_session
-    Session.current_session = Session.new(access_token, secret, api_version)
-    yield
+    Session.current_session = Session.new(access_token: access_token, app_secret: secret, api_version: api_version)
+    yield Session.current_session
     Session.current_session = original_session
   end
 


### PR DESCRIPTION
Updating the with_session method to use named params to match the Session initializer. 

Yielding Session.current_session allows for block usage: 
```
FacebookAds.with_session(args) do |session|

end
```
Existing blocks without "session" will not be broken