### PR TITLE
Properly determine if edge has a next page based off `next` key

### DIFF
--- a/lib/facebook_ads/edge.rb
+++ b/lib/facebook_ads/edge.rb
@@ -70,7 +70,7 @@ module FacebookAds
         end
 
         self.next_page_cursor = response.dig('paging', 'cursors', 'after')
-        self.has_next_page = !(response['data'].length < fetch_options[:limit])
+        self.has_next_page = !!response.dig('paging', 'next')
       end
     end
 


### PR DESCRIPTION
Currently, with regards to pagination, the library assumes that if there are fewer results than `limit`, there will not be a next page of results. This is not always true, as explained in the docs (quoted below). The proper way to determine whether there is a next page of results is by keying off the presence of the `next` key.

From [the docs](https://developers.facebook.com/docs/graph-api/using-graph-api/#cursors):

> **limit:** This is the maximum number of objects that may be returned. A query may return fewer than the value of limit due to filtering. Do not depend on the number of results being fewer than the limit value to indicate that your query reached the end of the list of data, use the absence of next instead as described below. For example, if you set limit to 10 and 9 results are returned, there may be more data available, but one item was removed due to privacy filtering. Some edges may also have a maximum on the limit value for performance reasons. In all cases, the API returns the correct pagination links.

> **next:** The Graph API endpoint that will return the next page of data. If not included, this is the last page of data. Due to how pagination works with visibility and privacy, it is possible that a page may be empty but contain a next paging link. Stop paging when the next link no longer appears.
