### PR TITLE
Update shortcuts.rb

### DIFF
--- a/lib/facebook_ads/helpers/shortcuts.rb
+++ b/lib/facebook_ads/helpers/shortcuts.rb
@@ -23,7 +23,7 @@ module FacebookAds
     end
 
     def ad_account(act_id)
-      act_id = 'act_' + act_id unless id =~ /^act_/
+      act_id = 'act_' + act_id unless act_id =~ /^act_/
       AdAccount.get(act_id)
     end
 


### PR DESCRIPTION
Calling 'ad_account' causes the following error. 
Believe that 'id' should be 'act_id'
```
NameError: undefined local variable or method `id' for FacebookAds:Module
```