### PR TITLE
Support version 5 of the countries gem

### DIFF
--- a/facebookbusiness.gemspec
+++ b/facebookbusiness.gemspec
@@ -32,12 +32,12 @@ Gem::Specification.new do |s|
     'https://github.com/facebook/facebook-ruby-business-sdk'
   s.license = 'Nonstandard'
 
-  s.required_ruby_version = '> 2.4'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_dependency 'concurrent-ruby', '~> 1.1'
   s.add_dependency 'faraday', '~> 1.0'
   s.add_dependency 'json', '~> 2.2'
-  s.add_dependency 'countries', '~>3.0'
+  s.add_dependency 'countries', '>= 3', '< 6'
   s.add_dependency 'money', '~> 6.13'
 
   s.add_development_dependency 'awesome_print', '~> 1.8'
@@ -50,7 +50,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rubocop', '~> 0.71'
-  s.add_development_dependency 'countries', '~>3.0'
   s.add_development_dependency 'money', '~> 6.13'
 
   s.files = Dir['LICENSE.txt', 'README.md', 'lib/**/*', 'bin/*']


### PR DESCRIPTION
It drops support for Ruby <2.7, as those are EOL: https://github.com/countries/countries/blob/9046bc79298986554f01ce6363c9310b1081a8f4/CHANGELOG.md#500-20220403-1744-0000

Otherwise this library only uses ISO3166::Country.search, which still works in a compatible way:

https://github.com/facebook/facebook-ruby-business-sdk/blob/f2e6f54084ee50c16acbb31410acd60aa5c44fda/lib/facebook_ads/ad_objects/server_side/util.rb#L137

Removed from add_development_dependency because I don't see it being used in dev, and AFAIK if it's in the regular dependencies, we don't need to repeat it in the development dependencies anyway.

Did not update Gemfile.lock since it doesn't appear to be kept up to date.