### PR TITLE
fix: CustomAudienceHelpers is broken for separation of positional and keyword arguments in Ruby 3.0

### DIFF
--- a/lib/facebook_ads/ad_objects/helpers/custom_audience_helpers.rb
+++ b/lib/facebook_ads/ad_objects/helpers/custom_audience_helpers.rb
@@ -51,11 +51,11 @@ module FacebookAds
     }
 
     def add_user(data, schema, options = {})
-      self.users.create(prepare_params(data, schema, options))
+      self.users.create(prepare_params(data, schema, **options))
     end
 
     def remove_user(data, schema, options = {})
-      self.users.destroy(prepare_params(data, schema, options))
+      self.users.destroy(prepare_params(data, schema, **options))
     end
 
     def prepare_params(data,

--- a/spec/lib/facebook_ads/ad_objects/helpers/custom_audience_helpers_spec.rb
+++ b/spec/lib/facebook_ads/ad_objects/helpers/custom_audience_helpers_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'FacebookAds::CustomAudienceHelpers' do
+  let(:test_class) { Struct.new('TestClass') { include FacebookAds::CustomAudienceHelpers } }
+
+  it '#prepare_params can parse options' do
+    data = [1, 2]
+    schema = "MOBILE_ADVERTISER_ID"
+    options = { app_ids: [3, 4] }
+
+    got = test_class.new.prepare_params(data, schema, **options)
+    expect(got).to eq(
+      payload: {
+        schema: "MOBILE_ADVERTISER_ID",
+        data: [1, 2],
+        is_raw: true,
+        app_ids: [3, 4],
+      },
+    )
+  end
+end


### PR DESCRIPTION
`CustomAudienceHelpers` is broken due to ruby3.0 spec changes.
This should be fixed since the minimum supported version is ruby3.0.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

