### PR TITLE
Pass scope parameter as a string, not a list of Permissions

### DIFF
--- a/lib/facebook_ads/ad_objects/business.rb
+++ b/lib/facebook_ads/ad_objects/business.rb
@@ -342,7 +342,7 @@ module FacebookAds
       edge.post 'Business' do |api|
         api.has_param :app_id, 'string'
         api.has_param :fbe_external_business_id, 'string'
-        api.has_param :scope, { list: 'Permission' }
+        api.has_param :scope, 'string'
         api.has_param :system_user_name, 'string'
       end
     end
@@ -932,7 +932,7 @@ module FacebookAds
       edge.post 'Business' do |api|
         api.has_param :asset, { list: 'int' }
         api.has_param :fetch_only, 'bool'
-        api.has_param :scope, { list: 'Permission' }
+        api.has_param :scope, 'string'
         api.has_param :set_token_expires_in_60_days, 'bool'
         api.has_param :system_user_id, 'int'
       end

--- a/lib/facebook_ads/ad_objects/user.rb
+++ b/lib/facebook_ads/ad_objects/user.rb
@@ -91,7 +91,7 @@ module FacebookAds
       edge.post 'User' do |api|
         api.has_param :business_app, 'int'
         api.has_param :page_id, 'string'
-        api.has_param :scope, { list: 'Permission' }
+        api.has_param :scope, 'string'
         api.has_param :set_token_expires_in_60_days, 'bool'
       end
     end


### PR DESCRIPTION
The scope parameter needs to be a string containing a comma-separated list of scopes, e.g. "ads_management,manage_pages".

Fixes #97.