### PR TITLE
gemspec: Allow Countries gem 6.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     facebookbusiness (20.0.0)
       concurrent-ruby (~> 1.1)
-      countries (>= 3, < 6)
+      countries (>= 3, < 7)
       faraday (~> 2.6)
       faraday-multipart (~> 1.0.4)
       json (~> 2.6)
@@ -84,6 +84,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/facebookbusiness.gemspec
+++ b/facebookbusiness.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 2.6'
   s.add_dependency 'faraday-multipart', '~> 1.0.4'
   s.add_dependency 'json', '~> 2.6'
-  s.add_dependency 'countries', '>= 3', '< 6'  
+  s.add_dependency 'countries', '>= 3', '< 7'
   s.add_dependency 'money', '~> 6.13'
 
   s.add_development_dependency 'awesome_print', '~> 1.8'


### PR DESCRIPTION
Countries, the gem, has released a 6.0.1 release, and we should allow that.

We added the version pin to "< 6" the last time this was updated.
https://github.com/facebook/facebook-ruby-business-sdk/commit/56588d4e4d02d1b1e9856a8de41b1670ca1ec8ed