### PR TITLE
gemspec: Allow Countries gem 8.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    facebookbusiness (22.0.0)
+    facebookbusiness (24.0.0)
       concurrent-ruby (~> 1.1)
-      countries (>= 3, < 7)
+      countries (>= 3, < 9)
       faraday (~> 2.6)
       faraday-multipart (~> 1.0, >= 1.0.4)
       json (~> 2.6)
@@ -87,6 +87,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/facebookbusiness.gemspec
+++ b/facebookbusiness.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 2.6'
   s.add_dependency 'faraday-multipart', '>= 1.0.4', '~> 1.0'
   s.add_dependency 'json', '~> 2.6'
-  s.add_dependency 'countries', '>= 3', '< 7'
+  s.add_dependency 'countries', '>= 3', '< 9'
   s.add_dependency 'money', '~> 6.13'
 
   s.add_development_dependency 'awesome_print', '~> 1.8'


### PR DESCRIPTION
This PR unpins [the Countries gem](https://github.com/countries/countries), allowing newer versions of it.

This is the same as #213 but with a new version.
